### PR TITLE
do not throw error in case file size exceeds limit or type mismatch

### DIFF
--- a/src/cropper.vue
+++ b/src/cropper.vue
@@ -642,13 +642,11 @@
         if (!this._fileSizeIsValid(file)) {
           this.loading = false
           this.$emit(events.FILE_SIZE_EXCEED_EVENT, file)
-          throw new Error('File size exceeds limit which is ' + this.fileSizeLimit + ' bytes.')
         }
         if (!this._fileTypeIsValid(file)) {
           this.loading = false
           this.$emit(events.FILE_TYPE_MISMATCH_EVENT, file)
           let type = file.type || file.name.toLowerCase().split('.').pop()
-          throw new Error(`File type (${type}) mimatches (${this.accept}).`)
         }
         if (typeof window !== 'undefined' && typeof window.FileReader !== 'undefined') {
           let fr = new FileReader()

--- a/src/cropper.vue
+++ b/src/cropper.vue
@@ -642,11 +642,13 @@
         if (!this._fileSizeIsValid(file)) {
           this.loading = false
           this.$emit(events.FILE_SIZE_EXCEED_EVENT, file)
+          return false
         }
         if (!this._fileTypeIsValid(file)) {
           this.loading = false
           this.$emit(events.FILE_TYPE_MISMATCH_EVENT, file)
           let type = file.type || file.name.toLowerCase().split('.').pop()
+          return false
         }
         if (typeof window !== 'undefined' && typeof window.FileReader !== 'undefined') {
           let fr = new FileReader()


### PR DESCRIPTION
Hello,

As far as I know `throw new Error` should be used to raise an error in case there is something wrong with the flow, not for the scenario of user input.

I have removed the lines that `throw new Error` for  file size exceeds limit & type mismatch as the events are to handle those situations.

I hope make sense.

Saludos!