### PR TITLE
Improvements to handling of loading events

### DIFF
--- a/src/cropper.vue
+++ b/src/cropper.vue
@@ -117,7 +117,7 @@ export default {
       imageSet: false,
       currentPointerCoord: null,
       currentIsInitial: false,
-      loading: false,
+      _loading: false,
       realWidth: 0, // only for when autoSizing is on
       realHeight: 0, // only for when autoSizing is on
       chosenFile: null,
@@ -152,6 +152,25 @@ export default {
         bottom: '10px'
       }
     },
+
+    loading: {
+      get: function() {
+        return this._loading
+      },
+      set: function(newValue) {
+        console.log("Set loading", newValue)
+        let oldValue = this._loading
+        this._loading = newValue
+        if (oldValue != newValue) {
+          if (this.passive) return
+          if (newValue) {
+            this.emitEvent(events.LOADING_START_EVENT)
+          } else {
+            this.emitEvent(events.LOADING_END_EVENT)
+          }
+        }
+      }
+    }
   },
 
   mounted () {
@@ -297,14 +316,6 @@ export default {
       // if (this.passive) return
       if (this.hasImage()) {
         this.$nextTick(this._draw)
-      }
-    },
-    loading (val) {
-      if (this.passive) return
-      if (val) {
-        this.emitEvent(events.LOADING_START_EVENT)
-      } else {
-        this.emitEvent(events.LOADING_END_EVENT)
       }
     },
     autoSizing (val) {

--- a/src/cropper.vue
+++ b/src/cropper.vue
@@ -158,7 +158,6 @@ export default {
         return this._loading
       },
       set: function(newValue) {
-        console.log("Set loading", newValue)
         let oldValue = this._loading
         this._loading = newValue
         if (oldValue != newValue) {

--- a/src/cropper.vue
+++ b/src/cropper.vue
@@ -659,9 +659,19 @@ export default {
         return
       }
       this.currentIsInitial = true
-      if (u.imageLoaded(img)) {
-        // this.emitEvent(events.INITIAL_IMAGE_LOADED_EVENT)
-        this._onload(img, +img.dataset['exifOrientation'], true)
+
+      let onError = () => {
+        this._setPlaceholders()
+        this.loading = false
+      }
+      this.loading = true
+      if (img.complete) {
+        if (u.imageLoaded(img)) {
+          // this.emitEvent(events.INITIAL_IMAGE_LOADED_EVENT)
+          this._onload(img, +img.dataset['exifOrientation'], true)
+        } else {
+          onError()
+        }
       } else {
         this.loading = true
         img.onload = () => {
@@ -670,7 +680,7 @@ export default {
         }
 
         img.onerror = () => {
-          this._setPlaceholders()
+          onError()
         }
       }
     },


### PR DESCRIPTION
Adds immediate failure check to assure the loading-end event is called in after loading-start was sent.

Changes the "this.loading" watcher to a setter to assure the loading events are sent out even if the loading state resolves back to initial state within one tick (in which case the watcher doesn't trigger at all)
