### PR TITLE
chosenFile with initial image

### DIFF
--- a/src/cropper.vue
+++ b/src/cropper.vue
@@ -477,14 +477,13 @@ export default {
       this.$refs.fileInput.click()
     },
 
-    remove () {
+    remove (keepChosenFile = false) {
       if (!this.imageSet) return
       this._setPlaceholders()
 
       let hadImage = this.img != null
       this.originalImage = null
       this.img = null
-      this.$refs.fileInput.value = ''
       this.imgData = {
         width: 0,
         height: 0,
@@ -495,7 +494,10 @@ export default {
       this.scaleRatio = null
       this.userMetadata = null
       this.imageSet = false
-      this.chosenFile = null
+      if (!keepChosenFile) {
+        this.$refs.fileInput.value = ''
+        this.chosenFile = null
+      }
       if (this.video) {
         this.video.pause()
         this.video = null
@@ -677,7 +679,7 @@ export default {
 
     _onload (img, orientation = 1, initial) {
       if (this.imageSet) {
-        this.remove()
+        this.remove(true)
       }
       this.originalImage = img
       this.img = img


### PR DESCRIPTION
When a file was chosen more than once (incl. when using initial image), the reset function would destroy the information about the currently chosen file (this.getChosenFile() === null)

The change tries to keep the chosenFile around so that the getChosenFile returns the last file chosen (as expected).